### PR TITLE
Add qir-runner to list of projects

### DIFF
--- a/src/_data/internal_projects.json
+++ b/src/_data/internal_projects.json
@@ -66,6 +66,19 @@
             ],
             "maturity": "",
             "owner": "qir-alliance"
+        },
+        {
+            "name": "qir-runner",
+            "url": "https://github.com/qir-alliance/qir-runner",
+            "docs": "https://github.com/qir-alliance/qir-runner/blob/main/README.md",
+            "logo": "",
+            "description": "QIR bytecode runner to assist with QIR development and validation ",
+            "tags": [
+                "rust",
+                "simulation"
+            ],
+            "maturity": "",
+            "owner": "qir-alliance"
         }
     ]
 }


### PR DESCRIPTION
The qir-runner project is missing from the list of projects at https://www.qir-alliance.org/projects/, such that this PR adds that project in order to help make it more visible to the community.